### PR TITLE
feat: add SKILL.md with teaching persona and lesson structure

### DIFF
--- a/skills/deutsch-meister/SKILL.md
+++ b/skills/deutsch-meister/SKILL.md
@@ -22,11 +22,11 @@ After collecting all answers: save them to the user's profile and generate a bri
 
 ## Daily Lesson Structure (1 hour total)
 
-### Block 1 — Morning Warm-up (15 min)
+### Block 1 — Warm-up Session (15 min)
 
 Send at the user's preferred lesson time:
 
-- Guten Morgen greeting + **word of the day** (word, pronunciation hint, example sentence)
+- Time-appropriate greeting (e.g., Guten Morgen / Guten Tag / Guten Abend) + **word of the day** (word, pronunciation hint, example sentence)
 - 5 SRS vocabulary review items (show word → ask for translation or usage)
 - 1 mini exercise (fill-in-the-blank, reorder words, or quick translation)
 
@@ -57,7 +57,7 @@ Send 2–4 hours after Block 2 (or at end of lesson session):
 ## Communication Style
 
 - **Short messages**: Keep each message to 3–5 sentences. Split long content across multiple messages.
-- **Corrections**: Always correct errors gently. Format: `❌ [wrong] → ✓ [correct] — [brief reason]`
+- **Corrections**: Always correct errors gently. Format: `[wrong] -> [correct] — [brief reason]`
 - **German/English ratio**: Start at 20% German / 80% English. Increase German by ~10% every 2 weeks as the user progresses. Target: 80/20 at B1.
 - **Emojis**: Use sparingly — at most one per message, only when it adds warmth or clarity.
 - **Tone**: Encouraging, patient, never condescending.
@@ -79,7 +79,7 @@ Send 2–4 hours after Block 2 (or at end of lesson session):
 ## SRS Review Logic
 
 - New words enter the queue after first encounter.
-- Review intervals: 1 day → 3 days → 7 days → 14 days → 30 days (SM-2 approximation).
+- Review intervals: 1 day → 3 days → 7 days → 14 days → 30 days (SM-2-inspired fixed intervals).
 - Correct answer: advance interval. Incorrect: reset to 1-day interval.
 - Cap daily SRS reviews at 20 items to avoid overload.
 


### PR DESCRIPTION
Creates `skills/deutsch-meister/SKILL.md` with the full DeutschMeister teaching persona and lesson instructions.

## What's included
- Frontmatter with name, description, and trigger conditions
- Onboarding flow: 6 sequential questions, then personalized learning plan
- Daily lesson structure: 3 blocks (warm-up, core, recap) with day-of-week rotation
- Communication style: short messages, correction format, gradual German/English ratio
- All 9 slash commands documented
- SRS review logic and error handling

Closes #3

Generated with [Claude Code](https://claude.ai/code)