### PR TITLE
feat: add CEFR A1 curriculum reference file

### DIFF
--- a/curriculum/a1.md
+++ b/curriculum/a1.md
@@ -25,7 +25,7 @@ Themes are ordered by difficulty and natural progression. Each theme builds on v
 - Wie geht es Ihnen? / Wie geht's? — Gut, danke. / Es geht.
 - Woher kommen Sie? — Ich komme aus …
 - Wo wohnen Sie? — Ich wohne in …
-- bitte, danke, entschuldigung, ja, nein
+- bitte, danke, Entschuldigung, ja, nein
 
 ### Theme 2 — Numbers (1–100)
 
@@ -162,7 +162,7 @@ Topics are ordered in logical pedagogical progression; each topic builds on the 
 | he / she / it | er / sie / es | |
 | we | wir | |
 | you (plural) | ihr | |
-| they / you (formal) | sie / Sie | Sie (formal) always capitalised |
+| they / you (formal) | sie / Sie | Sie (formal) always capitalized |
 
 ### Grammar 2 — Present Tense: Regular Verbs
 
@@ -175,7 +175,7 @@ Conjugation pattern for **-en** verbs (e.g., *machen, spielen, lernen*):
 | er/sie/es | -t | macht |
 | wir | -en | machen |
 | ihr | -t | macht |
-| sie/Sie | -en | machen/machen |
+| sie/Sie | -en | machen |
 
 **Stem-vowel verbs** (e→i/ie): sprechen → spricht; lesen → liest.
 
@@ -367,7 +367,7 @@ Used for commands, instructions, and polite requests.
 | Themes 11–15 | 7–9 | ~640 words |
 | Review & consolidation | 10–12 | ~800 words |
 
-**Passive vocabulary** (recognised but not actively produced) will be approximately 1.5× active vocabulary (~1,200 words).
+**Passive vocabulary** (recognized but not actively produced) will be approximately 1.5× active vocabulary (~1,200 words).
 
 ---
 


### PR DESCRIPTION
Creates `curriculum/a1.md` with a comprehensive CEFR A1 curriculum reference:

- 15 vocabulary themes with example words
- 15 grammar topics in logical pedagogical progression
- Word count targets (~800 active words by end of A1)
- 8–12 week timeline with phase breakdown and lesson structure
- Goethe-Zertifikat A1 exam alignment notes

Closes #4

Generated with [Claude Code](https://claude.ai/code)